### PR TITLE
[project] Cleanup `lien check` warnings.

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -350,7 +350,7 @@
   (default 10)."
   ([prefix]              (ephemeral-file prefix "" 10))
   ([prefix suffix]       (ephemeral-file prefix suffix 10))
-  ([prefix suffix tries] (when-let [created (temp-create prefix suffix tries create)]
+  ([prefix suffix tries] (when-let [^File created (temp-create prefix suffix tries create)]
                            (doto created .deleteOnExit))))
 
 (defn ephemeral-dir
@@ -359,7 +359,7 @@
   (default 10)."
   ([prefix]              (ephemeral-dir prefix "" 10))
   ([prefix suffix]       (ephemeral-dir prefix suffix 10))
-  ([prefix suffix tries] (when-let [created (temp-create prefix suffix tries mkdirs)]
+  ([prefix suffix tries] (when-let [^File created (temp-create prefix suffix tries mkdirs)]
                            (doto created .deleteOnExit))))
 
 ; Taken from https://github.com/jkk/clj-glob. (thanks Justin!)
@@ -449,7 +449,7 @@
   (- (int c) 48))
 
 (defn- chmod-octal-digit
-  [f i user?]
+  [^File f i user?]
   (if (> i 7)
     (throw (IllegalArgumentException. "Bad mode"))
     (do (.setReadable f (pos? (bit-and i 4)) user?)

--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -323,7 +323,7 @@
 
 (defn- temp-create
   "Create a temporary file or dir, trying n times before giving up."
-  [prefix suffix tries f]
+  ^File [prefix suffix tries f]
   (let [tmp (file (tmpdir) (temp-name prefix suffix))]
     (when (pos? tries)
       (if (f tmp)
@@ -350,7 +350,7 @@
   (default 10)."
   ([prefix]              (ephemeral-file prefix "" 10))
   ([prefix suffix]       (ephemeral-file prefix suffix 10))
-  ([prefix suffix tries] (when-let [^File created (temp-create prefix suffix tries create)]
+  ([prefix suffix tries] (when-let [created (temp-create prefix suffix tries create)]
                            (doto created .deleteOnExit))))
 
 (defn ephemeral-dir
@@ -359,7 +359,7 @@
   (default 10)."
   ([prefix]              (ephemeral-dir prefix "" 10))
   ([prefix suffix]       (ephemeral-dir prefix suffix 10))
-  ([prefix suffix tries] (when-let [^File created (temp-create prefix suffix tries mkdirs)]
+  ([prefix suffix tries] (when-let [created (temp-create prefix suffix tries mkdirs)]
                            (doto created .deleteOnExit))))
 
 ; Taken from https://github.com/jkk/clj-glob. (thanks Justin!)

--- a/src/me/raynes/fs/compression.clj
+++ b/src/me/raynes/fs/compression.clj
@@ -9,7 +9,7 @@
                                                     xz.XZCompressorInputStream)
            (java.io ByteArrayOutputStream File)))
 
-(defn- check-final-path-inside-target-dir! [f target-dir entry]
+(defn- check-final-path-inside-target-dir! [^File f ^File target-dir entry]
   (when-not (-> f .getCanonicalPath (.startsWith (str (.getCanonicalPath target-dir) File/separator)))
     (throw (ex-info "Expanding entry would be created outside target dir"
                     {:entry entry


### PR DESCRIPTION
Hi :wave: - thanks for maintaining this lib, we use it all over the place and definitely appreciate your efforts.

On master, `lein check` surfaces some warnings:
```
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
harold@straylight:~/play/fs [master]$ lein check
Compiling namespace me.raynes.fs
Reflection warning, me/raynes/fs.clj:354:28 - reference to field deleteOnExit can't be resolved.
Reflection warning, me/raynes/fs.clj:363:28 - reference to field deleteOnExit can't be resolved.
Reflection warning, me/raynes/fs.clj:455:9 - call to method setReadable can't be resolved (target class is unknown).
Reflection warning, me/raynes/fs.clj:456:9 - call to method setWritable can't be resolved (target class is unknown).
Reflection warning, me/raynes/fs.clj:457:9 - call to method setExecutable can't be resolved (target class is unknown).
Compiling namespace me.raynes.fs.compression
Reflection warning, me/raynes/fs/compression.clj:13:37 - reference to field getCanonicalPath can't be resolved.
Reflection warning, me/raynes/fs/compression.clj:13:55 - reference to field getCanonicalPath can't be resolved.
Reflection warning, me/raynes/fs/compression.clj:13:37 - call to method startsWith can't be resolved (target class is unknown).
```

On this branch, those are cleaned up:
```
Switched to branch 'lein-check-clean-2020-04-27'
Your branch is up to date with 'origin/lein-check-clean-2020-04-27'.
harold@straylight:~/play/fs [lein-check-clean-2020-04-27]$ lein check
Compiling namespace me.raynes.fs
Compiling namespace me.raynes.fs.compression
```

These warnings bubble up into our tools when we include this library, so I thought I'd dive in and clean them up. Thanks for your time and consideration.