### PR TITLE
[Fix #12] Introduce feature flags to make extension of `io/Coercions` optional

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -3,7 +3,8 @@
   (:refer-clojure :exclude [name parents])
   (:require [clojure.zip :as zip]
             [clojure.java.io :as io]
-            [clojure.java.shell :as sh])
+            [clojure.java.shell :as sh]
+            [me.raynes.fs.feature-flags :as feature-flags])
   (:import [java.io File FilenameFilter]
            [java.nio.file Files Path LinkOption CopyOption]
            [java.nio.file.attribute FileAttribute]))
@@ -141,10 +142,11 @@
   [path]
   (predicate isHidden (file path)))
 
-(extend-protocol io/Coercions
-  Path
-  (as-file [this] (.toFile this))
-  (as-url [this] (.. this (toFile) (toURL))))
+(when feature-flags/extend-coercions?
+  (extend-protocol io/Coercions
+    Path
+    (as-file [this] (.toFile this))
+    (as-url [this] (.. this (toFile) (toURL)))))
 
 (defn- ^Path as-path
   "Convert `path` to a `java.nio.file.Path`.

--- a/src/me/raynes/fs/feature_flags.clj
+++ b/src/me/raynes/fs/feature_flags.clj
@@ -1,0 +1,12 @@
+(ns me.raynes.fs.feature-flags
+  "Compile-time feature flags.
+
+  In order to use them:
+
+  * `require` this ns before any other ns from this lib.
+  * `alter-var-root` a given feature flag within this ns to a different, desired value
+  * proceed to `require` the rest of this library.")
+
+(def extend-coercions?
+  "Should the clojure.java.io/Coercions protocol be extended by this library?"
+  true)


### PR DESCRIPTION
These allow dependent libraries to use `fs` without the side-effect of `extend-protocol`.

Otherwise one can unawarely create issues, as seen in https://github.com/clojure-emacs/clj-refactor.el/issues/508.

https://clojure.org/reference/protocols#_guidelines_for_extension says:

> If you don’t own the protocol or the target type, you should only extend in app (not public lib) code, and expect to maybe be broken by either owner.

So what `fs` was doing wasn't ideal anyway.

The proposed feature flag is the best way I found such that:

* the existing behavior is preserved
* refactor-nrepl can effectively require this ns and modify the feature flag without affecting anyone else
  * this is made possible by https://github.com/benedekfazekas/mranderson - it 'inlines' (renames) the whole ns, so we end up only changing _our_ copy of the fs namespaces.
* Regular apps can also change the value if desired
  * it's a little more risky for them because they don't have mranderson. But OTOH an app is more of "closed system" which can be quite exhaustively unit-tested.

Cheers - V